### PR TITLE
[Fix] Allow selecting between nature paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.175.0
+- Fix route selector to show Path 1 and Path 2 separately
+- Bumped plugin version
+
 ### 2.174.0
 - Split nature trail into two selectable routes
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.174.0
+Version: 2.175.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages

--- a/js/mapbox-init.js
+++ b/js/mapbox-init.js
@@ -136,8 +136,8 @@
         <div id="gn-nav-controls" style="padding: 6px; background: white;">
             <select id="gn-route-select" class="gn-nav-select">
               <option value="">Select Route</option>
-              <option value="path1">Διαδρομή 1</option>
-              <option value="path2">Διαδρομή 2</option>
+              <option value="path1">Path 1</option>
+              <option value="path2">Path 2</option>
               <option value="paphos">Paphos → Giolou</option>
               <option value="airport">Paphos Airport → Giolou</option>
             </select>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.174.0
+Stable tag: 2.175.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
+= 2.175.0 =
+* Fix route selector to show Path 1 and Path 2 separately
+* Bumped plugin version
 = 2.174.0 =
 * Split nature trail into two selectable routes
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- show Path 1 and Path 2 separately in route selector
- bump plugin version to 2.175.0

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js/mapbox-init.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68ac218a8818832793f7cc0e1763845f