### PR TITLE
[Fix] Assign path meta for default locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.177.0
+- Assign path value when importing default locations so Path 2 draws correctly
+- Bumped plugin version
 ### 2.176.0
 - Add missing coordinate to Path 2 dataset so route draws correctly
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.176.0
+Version: 2.177.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -100,54 +100,55 @@ function gn_location_exists($title, $lat = null, $lng = null) {
  * plugin is first installed.
  */
 function gn_import_default_locations() {
-    $files = [
-        plugin_dir_path(__FILE__) . 'data/nature-path-1.json',
-        plugin_dir_path(__FILE__) . 'data/nature-path-2.json',
-    ];
+  $files = [
+    'path1' => plugin_dir_path(__FILE__) . 'data/nature-path-1.json',
+    'path2' => plugin_dir_path(__FILE__) . 'data/nature-path-2.json',
+  ];
 
-    foreach ($files as $json_file) {
-        if (!file_exists($json_file)) {
-            continue;
-        }
-
-        $json = file_get_contents($json_file);
-        $locations = json_decode($json, true);
-        if (!is_array($locations)) {
-            continue;
-        }
-
-        foreach ($locations as $index => $location) {
-            if (empty($location['title'])) {
-                continue;
-            }
-
-            $lat = $location['lat'] ?? null;
-            $lng = $location['lng'] ?? null;
-            if (gn_location_exists($location['title'], $lat, $lng)) {
-                continue;
-            }
-
-            $post_id = wp_insert_post([
-                'post_title'   => wp_strip_all_tags($location['title']),
-                'post_content' => $location['content'] ?? '',
-                'post_status'  => 'publish',
-                'post_type'    => 'map_location',
-            ]);
-
-            if (!is_wp_error($post_id)) {
-                if (isset($location['lat'])) {
-                    update_post_meta($post_id, 'latitude', $location['lat']);
-                }
-                if (isset($location['lng'])) {
-                    update_post_meta($post_id, 'longitude', $location['lng']);
-                }
-                if (isset($location['waypoint'])) {
-                    update_post_meta($post_id, '_gn_waypoint', $location['waypoint'] ? '1' : '');
-                }
-                update_post_meta($post_id, '_gn_location_order', $index);
-            }
-        }
+  foreach ($files as $path_key => $json_file) {
+    if (!file_exists($json_file)) {
+      continue;
     }
+
+    $json = file_get_contents($json_file);
+    $locations = json_decode($json, true);
+    if (!is_array($locations)) {
+      continue;
+    }
+
+    foreach ($locations as $index => $location) {
+      if (empty($location['title'])) {
+        continue;
+      }
+
+      $lat = $location['lat'] ?? null;
+      $lng = $location['lng'] ?? null;
+      if (gn_location_exists($location['title'], $lat, $lng)) {
+        continue;
+      }
+
+      $post_id = wp_insert_post([
+        'post_title'   => wp_strip_all_tags($location['title']),
+        'post_content' => $location['content'] ?? '',
+        'post_status'  => 'publish',
+        'post_type'    => 'map_location',
+      ]);
+
+      if (!is_wp_error($post_id)) {
+        if (isset($location['lat'])) {
+          update_post_meta($post_id, 'latitude', $location['lat']);
+        }
+        if (isset($location['lng'])) {
+          update_post_meta($post_id, 'longitude', $location['lng']);
+        }
+        if (isset($location['waypoint'])) {
+          update_post_meta($post_id, '_gn_waypoint', $location['waypoint'] ? '1' : '');
+        }
+        update_post_meta($post_id, '_gn_path', $path_key === 'path2' ? '2' : '1');
+        update_post_meta($post_id, '_gn_location_order', $index);
+      }
+    }
+  }
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.176.0
+Stable tag: 2.177.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
+= 2.177.0 =
+* Assign path value when importing default locations so Path 2 draws correctly
+* Bumped plugin version
 = 2.176.0 =
 * Add missing coordinate to Path 2 dataset so route draws correctly
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- set `_gn_path` meta when importing bundled JSON so Path 2 has coordinates
- bump plugin version to 2.177.0

## Testing
- `php -l gn-mapbox-plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac3f6b831c8327aacf5d5d5d6615cd