### PR TITLE
[Fix] Make Giolou map shortcode responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.178.0
+- Make `[gn_mapbox_giolou]` fill the full width and height of its column
+- Bumped plugin version
 ### 2.177.0
 - Assign path value when importing default locations so Path 2 draws correctly
 - Bumped plugin version

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -6,6 +6,13 @@
   z-index: 1;
 }
 
+/* === Giolou Map Shortcode === */
+.gn-mapbox-giolou {
+  width: 100%;
+  height: 100%;
+  min-height: 400px;
+}
+
 /* Popup layout */
 #gn-mapbox-map .mapboxgl-popup-content {
   width: clamp(280px, 90vw, 500px) !important;

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.177.0
+Version: 2.178.0
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -818,7 +818,7 @@ function gn_mapbox_giolou_shortcode() {
     }
     ob_start();
     ?>
-    <div id="gn-mapbox-giolou" style="width: 100%; height: 400px;"></div>
+    <div id="gn-mapbox-giolou" class="gn-mapbox-giolou"></div>
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.177.0
+Stable tag: 2.178.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
+= 2.178.0 =
+* Make `[gn_mapbox_giolou]` fill the full width and height of its column
+* Bumped plugin version
 = 2.177.0 =
 * Assign path value when importing default locations so Path 2 draws correctly
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- ensure `[gn_mapbox_giolou]` map fills parent column via CSS class
- bump plugin version to 2.178.0 and update changelog

## Testing
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac4475be8c8327995e30a8497b2fc4