### PR TITLE
[Fix] Revert to 2.177.0 and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
-### 2.178.0
-- Make `[gn_mapbox_giolou]` fill the full width and height of its column
+### 2.177.1
+- Revert responsive map layout changes
 - Bumped plugin version
 ### 2.177.0
 - Assign path value when importing default locations so Path 2 draws correctly

--- a/css/mapbox-style.css
+++ b/css/mapbox-style.css
@@ -6,13 +6,6 @@
   z-index: 1;
 }
 
-/* === Giolou Map Shortcode === */
-.gn-mapbox-giolou {
-  width: 100%;
-  height: 100%;
-  min-height: 400px;
-}
-
 /* Popup layout */
 #gn-mapbox-map .mapboxgl-popup-content {
   width: clamp(280px, 90vw, 500px) !important;

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.178.0
+Version: 2.177.1
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -818,7 +818,7 @@ function gn_mapbox_giolou_shortcode() {
     }
     ob_start();
     ?>
-    <div id="gn-mapbox-giolou" class="gn-mapbox-giolou"></div>
+    <div id="gn-mapbox-giolou" style="width: 100%; height: 400px;"></div>
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
     <script>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.178.0
+Stable tag: 2.177.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,8 +40,8 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
-= 2.178.0 =
-* Make `[gn_mapbox_giolou]` fill the full width and height of its column
+= 2.177.1 =
+* Revert responsive map layout changes
 * Bumped plugin version
 = 2.177.0 =
 * Assign path value when importing default locations so Path 2 draws correctly


### PR DESCRIPTION
## Summary
- Revert responsive map layout changes introduced in previous merge
- Bump plugin version to 2.177.1 across plugin files and documentation

## Testing
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac45e4c0888327a7ee1ac5ef20b7b4