### PR TITLE
[Fix] Attach default photos to imported locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.177.5
+- Attach default photos to imported locations so each place starts with its image
+- Bumped plugin version
 ### 2.177.4
 - Add gallery images for nature path locations
 - Correct Θεοτοκούσα name

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.177.4
+Version: 2.177.5
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -146,6 +146,26 @@ function gn_import_default_locations() {
         }
         update_post_meta($post_id, '_gn_path', $path_key === 'path2' ? '2' : '1');
         update_post_meta($post_id, '_gn_location_order', $index);
+
+        if (!empty($location['gallery']) && is_array($location['gallery'])) {
+          $ids = array_values(array_filter(array_map('intval', $location['gallery'])));
+          if ($ids) {
+            update_post_meta($post_id, '_gn_location_photos', implode(',', $ids));
+            foreach ($ids as $img_id) {
+              wp_update_post([
+                'ID'          => $img_id,
+                'post_parent' => $post_id,
+              ]);
+            }
+            if (!empty($location['image']) && is_numeric($location['image'])) {
+              set_post_thumbnail($post_id, intval($location['image']));
+            } else {
+              set_post_thumbnail($post_id, $ids[0]);
+            }
+          }
+        } elseif (!empty($location['image']) && is_numeric($location['image'])) {
+          set_post_thumbnail($post_id, intval($location['image']));
+        }
       }
     }
   }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.177.4
+Stable tag: 2.177.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
+= 2.177.5 =
+* Attach default photos to imported locations so each place starts with its image
+* Bumped plugin version
 = 2.177.4 =
 * Add gallery images for nature path locations
 * Correct Θεοτοκούσα name


### PR DESCRIPTION
## Summary
- ensure default data images are attached to imported map locations and used as featured photos
- bump plugin version to 2.177.5 and update changelog

## Testing
- `php -l gn-mapbox-plugin.php`
- `npx eslint js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac84d3ac4c8327992de09c76384a0c