### PR TITLE
[Fix] Exclude featured image from gallery output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.177.6
+- Exclude featured image from gallery output to avoid duplicates
+- Bumped plugin version
 ### 2.177.5
 - Attach default photos to imported locations so each place starts with its image
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.177.5
+Version: 2.177.6
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -496,8 +496,12 @@ function gn_get_map_locations() {
 
         $gallery_ids = get_post_meta(get_the_ID(), '_gn_location_photos', true);
         $gallery = [];
+        $featured_id = get_post_thumbnail_id();
         if ($gallery_ids) {
             foreach (explode(',', $gallery_ids) as $gid) {
+                if ($featured_id && intval($gid) === intval($featured_id)) {
+                    continue;
+                }
                 $attachment = get_post($gid);
                 if (!$attachment) continue;
                 if (strpos($attachment->post_mime_type, 'video') === 0) {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.177.5
+Stable tag: 2.177.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
+= 2.177.6 =
+* Exclude featured image from gallery output to avoid duplicates
+* Bumped plugin version
 = 2.177.5 =
 * Attach default photos to imported locations so each place starts with its image
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- avoid showing the featured image twice by skipping it when building gallery arrays
- bump plugin version to 2.177.6 with updated changelog

## Testing
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac8757d0308327bcaa8ea33ea2afad