### PR TITLE
[Feature] Add cafe map shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 - `[gn_map]` shortcode embeds a fully interactive Mapbox map anywhere on your site.
 - `[gn_mapbox_giolou]` shortcode shows Giolou with a marker and red boundary line around the village.
 - `[gn_mapbox_giolou_paphos]` and `[gn_mapbox_paphos_airport]` provide driving directions between popular destinations.
+- `[gn_mapbox_palati]`, `[gn_mapbox_kokos_coffee]` and `[gn_mapbox_coffee_rooster]` show maps of local cafés.
  - Responsive popups display images, descriptions and media upload forms.
  - Gallery items open in a lightbox that scales beautifully on all devices.
 - Draggable navigation panel offers driving, walking and cycling directions with voice guidance.
@@ -28,6 +29,9 @@ This WordPress plugin displays custom post type locations on a Mapbox map. It al
 
 ## Usage
 Create `Map Location` posts with latitude and longitude fields and place the `[gn_map]` shortcode on any page.
+### 2.177.7
+- Add shortcodes `[gn_mapbox_palati]`, `[gn_mapbox_kokos_coffee]` and `[gn_mapbox_coffee_rooster]`
+- Bumped plugin version
 ### 2.177.6
 - Exclude featured image from gallery output to avoid duplicates
 - Bumped plugin version

--- a/gn-mapbox-plugin.php
+++ b/gn-mapbox-plugin.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: GN Mapbox Locations with ACF
 Description: Display custom post type locations using Mapbox with ACF-based coordinates, navigation, elevation, optional galleries and full debug panel.
-Version: 2.177.6
+Version: 2.177.7
 Author: George Nicolaou
 Text Domain: gn-mapbox
 Domain Path: /languages
@@ -982,6 +982,118 @@ function gn_mapbox_giolou_100_shortcode() {
     return ob_get_clean();
 }
 add_shortcode('gn_mapbox_giolou_100', 'gn_mapbox_giolou_100_shortcode');
+
+/**
+ * Display map for Το Παλάτι restaurant.
+ * Usage: [gn_mapbox_palati]
+ */
+function gn_mapbox_palati_shortcode() {
+    $token = get_option('gn_mapbox_token');
+    if (!$token) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
+    ob_start();
+    ?>
+    <div id="gn-mapbox-palati" style="width:100%;height:400px;"></div>
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script>
+      mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
+      const palatiMap = new mapboxgl.Map({
+        container: 'gn-mapbox-palati',
+        style: 'mapbox://styles/mapbox/satellite-streets-v11',
+        center: [32.473355, 34.925029],
+        zoom: 18
+      });
+      new mapboxgl.Marker()
+        .setLngLat([32.473355, 34.925029])
+        .setPopup(new mapboxgl.Popup().setText('Το Παλάτι'))
+        .addTo(palatiMap);
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_palati', 'gn_mapbox_palati_shortcode');
+
+/**
+ * Display map for Kokos Coffee using Mapbox geocoding.
+ * Usage: [gn_mapbox_kokos_coffee]
+ */
+function gn_mapbox_kokos_coffee_shortcode() {
+    $token = get_option('gn_mapbox_token');
+    if (!$token) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
+    ob_start();
+    ?>
+    <div id="gn-mapbox-kokos-coffee" style="width:100%;height:400px;"></div>
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script>
+      mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
+      const kokosMap = new mapboxgl.Map({
+        container: 'gn-mapbox-kokos-coffee',
+        style: 'mapbox://styles/mapbox/satellite-streets-v11',
+        center: [32.4773453, 34.9220437],
+        zoom: 18
+      });
+      fetch('https://api.mapbox.com/geocoding/v5/mapbox.places/' + encodeURIComponent('Kokos Coffee Giolou') + '.json?access_token=' + mapboxgl.accessToken)
+        .then(response => response.json())
+        .then(data => {
+          if (data.features && data.features.length) {
+            const [lng, lat] = data.features[0].center;
+            kokosMap.setCenter([lng, lat]);
+            new mapboxgl.Marker()
+              .setLngLat([lng, lat])
+              .setPopup(new mapboxgl.Popup().setText('Kokos Coffee'))
+              .addTo(kokosMap);
+          }
+        });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_kokos_coffee', 'gn_mapbox_kokos_coffee_shortcode');
+
+/**
+ * Display map for Coffee Rooster using Mapbox geocoding.
+ * Usage: [gn_mapbox_coffee_rooster]
+ */
+function gn_mapbox_coffee_rooster_shortcode() {
+    $token = get_option('gn_mapbox_token');
+    if (!$token) {
+        return '<p class="gn-mapbox-error">' . esc_html__('Mapbox access token missing. Set one under Settings → GN Mapbox.', 'gn-mapbox') . '</p>';
+    }
+    ob_start();
+    ?>
+    <div id="gn-mapbox-coffee-rooster" style="width:100%;height:400px;"></div>
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script>
+      mapboxgl.accessToken = '<?php echo esc_js($token); ?>';
+      const roosterMap = new mapboxgl.Map({
+        container: 'gn-mapbox-coffee-rooster',
+        style: 'mapbox://styles/mapbox/satellite-streets-v11',
+        center: [32.4773453, 34.9220437],
+        zoom: 18
+      });
+      fetch('https://api.mapbox.com/geocoding/v5/mapbox.places/' + encodeURIComponent('Coffee Rooster Giolou') + '.json?access_token=' + mapboxgl.accessToken)
+        .then(response => response.json())
+        .then(data => {
+          if (data.features && data.features.length) {
+            const [lng, lat] = data.features[0].center;
+            roosterMap.setCenter([lng, lat]);
+            new mapboxgl.Marker()
+              .setLngLat([lng, lat])
+              .setPopup(new mapboxgl.Popup().setText('Coffee Rooster'))
+              .addTo(roosterMap);
+          }
+        });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('gn_mapbox_coffee_rooster', 'gn_mapbox_coffee_rooster_shortcode');
 
 // Paphos to Giolou
 function gn_mapbox_giolou_to_paphos_shortcode() {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: georgewebdev
 Tags: mapbox,acf,locations,map
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 2.177.6
+Stable tag: 2.177.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,6 +40,9 @@ Enable the Debug Panel option in **Settings → GN Mapbox** to output verbose lo
 Markers are logged in the order they appear in `data/nature-path-1.json` and `data/nature-path-2.json`.
 
 == Changelog ==
+= 2.177.7 =
+* Add `[gn_mapbox_palati]`, `[gn_mapbox_kokos_coffee]` and `[gn_mapbox_coffee_rooster]` shortcodes
+* Bumped plugin version
 = 2.177.6 =
 * Exclude featured image from gallery output to avoid duplicates
 * Bumped plugin version


### PR DESCRIPTION
## Summary
- add shortcodes for Το Παλάτι, Kokos Coffee, and Coffee Rooster maps
- document new cafe shortcodes and bump plugin version to 2.177.7

## Testing
- `php -l gn-mapbox-plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_68adb49331f8832794e36e8941e141ba